### PR TITLE
Add a new step when requesting more info for the lab

### DIFF
--- a/app/controllers/backstage/labs_controller.rb
+++ b/app/controllers/backstage/labs_controller.rb
@@ -22,6 +22,8 @@ class Backstage::LabsController < Backstage::BackstageController
     @lab = Lab.friendly.find(params[:id])
   end
 
+  alias edit_request_more_info edit
+
   def update
     @lab = Lab.friendly.find(params[:id])
     if @lab.update_attributes(lab_params)
@@ -40,7 +42,6 @@ class Backstage::LabsController < Backstage::BackstageController
       reject
       remove
       referee_requests_admin_approval
-      request_more_info
       need_more_info
     ).each do |verb|
     define_method(verb) do
@@ -52,6 +53,21 @@ class Backstage::LabsController < Backstage::BackstageController
       else
         redirect_to backstage_lab_path(@lab), notice: "Could not #{verb} lab"
       end
+    end
+  end
+
+  def request_more_info
+    @lab = Lab.friendly.find(params[:id])
+
+    if @lab.update_attributes(lab_params)
+      verbed = action_to_verb[action_name.parameterize.underscore.to_sym]
+
+      if @lab.send("#{action_name}!", current_user)
+        lab_send_action("#{verbed}")
+        redirect_to backstage_labs_path, notice: "Lab #{verbed.tr('_', ' ')}"
+      end
+    else
+      render :edit_request_more_info
     end
   end
 

--- a/app/controllers/concerns/labs_operations.rb
+++ b/app/controllers/concerns/labs_operations.rb
@@ -19,7 +19,7 @@ module LabsOperations
   end
 
   def lab_send_action(verbed)
-    UserMailer.send("lab_#{verbed}", @lab.id)
+    UserMailer.send("lab_#{verbed}", @lab.id).deliver_now
     mails_referees(verbed)
   end
 

--- a/app/controllers/labs_controller.rb
+++ b/app/controllers/labs_controller.rb
@@ -161,6 +161,7 @@ private
       :tools,
       :network,
       :programs,
+      :improve_approval_application,
       capabilities: [ ],
       facilities_attributes: [:id, :thing_id, '_destroy' ],
       links_attributes: [ :id, :link_id, :url, '_destroy' ],

--- a/app/helpers/organizations/labs_helper.rb
+++ b/app/helpers/organizations/labs_helper.rb
@@ -1,2 +1,16 @@
 module Organizations::LabsHelper
+  def improve_approval_application_default_value(lab)
+    %{
+        Hi #{lab.creator.first_name},
+        more information were requested for your lab #{lab}. This means that either the platform admins, or the designated referees would like to know more about your lab.
+
+        Please add more information to the slug and description fields of the lab form so that we can learn more about your Fablab. -
+
+        You can check your lab profile at:
+        #{lab_url(lab)}
+
+        If you have questions regarding the approval process for fablabs, you can check the following doc:
+        "http://www.fablabs.io/labs/docs/approval_process"
+      }
+  end
 end

--- a/app/models/concerns/approve_workflow.rb
+++ b/app/models/concerns/approve_workflow.rb
@@ -15,6 +15,7 @@ module ApproveWorkflow
       end
       state :need_more_info do
         event :lab_adds_info, transition_to: :more_info_added
+        event :request_more_info, transition_to: :need_more_info
         event :approve, transition_to: :approved
         event :reject, transition_to: :rejected
         event :remove, transition_to: :removed

--- a/app/views/backstage/labs/edit_request_more_info.html.haml
+++ b/app/views/backstage/labs/edit_request_more_info.html.haml
@@ -1,0 +1,21 @@
+= render "backstage/header"
+
+.container
+  = title "Editing #{@lab}"
+  = simple_form_for [:backstage, @lab], url: request_more_info_backstage_lab_path do |f|
+    = render "form_errors", resource: @lab
+
+    .edit-lab
+
+    %fieldset
+      %legend
+        Approval process
+      .row
+        .col-lg-12
+          %p
+            = f.input :improve_approval_application,
+              input_html: { value: improve_approval_application_default_value(@lab) }
+
+    .row
+      .col-lg-12
+        = f.submit 'save', class: 'btn btn-primary'

--- a/app/views/backstage/labs/show.html.haml
+++ b/app/views/backstage/labs/show.html.haml
@@ -10,11 +10,19 @@
           %td
             = @lab.current_state
             - @lab.current_state.events.keys.each do |event|
+              - if current_user.is_referee? || current_user.is_unique_referee? || current_user.has_role?(:superadmin)
+                - if 'request_more_info' == event.to_s
+                  = button_to "#{event.capitalize.to_s.tr('_', ' ')}",
+                    { controller: 'labs', action: event },
+                    method: :get,
+                    class:  'btn btn-primary',
+                    id:     'event'
+
               - if current_user.is_referee? or current_user.is_unique_referee?
-                - if ['referee_approves', 'request_more_info', 'referee_requests_admin_approval', 'referee_rejects'].include? event.to_s
+                - if ['referee_approves', 'referee_requests_admin_approval', 'referee_rejects'].include? event.to_s
                   = button_to "#{event.capitalize.to_s.tr('_', ' ')}", {controller: 'labs', action: event}, method: :patch, class: 'btn btn-primary', id: 'event'
               - if current_user.has_role? :superadmin
-                - if ['approve', 'request_more_info', 'reject', 'remove'].include? event.to_s
+                - if ['approve', 'reject', 'remove'].include? event.to_s
                   = button_to "#{event.capitalize.to_s.tr('_', ' ')}", {controller: 'labs', action: event}, method: :patch, class: 'btn btn-primary', id: 'event'
         - if @lab.referee.present?
           %tr

--- a/app/views/user_mailer/lab_more_info_needed.text.haml
+++ b/app/views/user_mailer/lab_more_info_needed.text.haml
@@ -1,14 +1,4 @@
-Hi #{@user.first_name},
-
-more information were requested for your lab #{@lab}. This means that either the platform admins, or the designated referees
-would like to know more about your lab.
-
-Please add more information to the slug and description fields of the lab form so that we can learn more about your Fablab. -
-
-You can check your lab profile at:
-
-\#{lab_url(@lab)}
-
-If you have questions regarding the approval process for fablabs, you can check the following doc:
-
-\"http://www.fablabs.io/labs/docs/approval_process"
+- if @lab.improve_approval_application.present?
+  = @lab.improve_approval_application.html_safe
+- else
+  = improve_approval_application_default_value(@lab)

--- a/app/views/user_mailer/lab_requested_more_info.text.haml
+++ b/app/views/user_mailer/lab_requested_more_info.text.haml
@@ -1,14 +1,4 @@
-Hi #{@user.first_name},
-
-more information were requested for your lab #{@lab}. This means that either the platform admins, or the designated referees
-would like to know more about your lab.
-
-Please add more information to the slug and description fields of the lab form so that we can learn more about your Fablab. -
-
-You can check your lab profile at:
-
-\#{lab_url(@lab)}
-
-If you have questions regarding the approval process for fablabs, you can check the following doc:
-
-\"http://www.fablabs.io/labs/docs/approval_process"
+- if @lab.improve_approval_application.present?
+  = @lab.improve_approval_application.html_safe
+- else
+  = improve_approval_application_default_value(@lab)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
           patch :remove
           patch :referee_approves
           patch :referee_rejects
+          get   :request_more_info, to: 'labs#edit_request_more_info'
           patch :request_more_info
           patch :referee_requests_admin_approval
           patch :admin_approves

--- a/db/migrate/20180714171543_improve_approval_application_to_labs.rb
+++ b/db/migrate/20180714171543_improve_approval_application_to_labs.rb
@@ -1,0 +1,5 @@
+class ImproveApprovalApplicationToLabs < ActiveRecord::Migration
+  def change
+    add_column :labs, :improve_approval_application, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180710172343) do
+ActiveRecord::Schema.define(version: 20180714171543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20180710172343) do
     t.integer  "user_id"
     t.integer  "lab_id"
     t.integer  "started_in"
-    t.string   "type",        limit: 255
+    t.string   "type"
     t.integer  "approver_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -33,22 +33,22 @@ ActiveRecord::Schema.define(version: 20180710172343) do
 
   create_table "activities", force: :cascade do |t|
     t.integer  "creator_id"
-    t.string   "action",         limit: 255
+    t.string   "action"
     t.integer  "trackable_id"
-    t.string   "trackable_type", limit: 255
+    t.string   "trackable_type"
     t.datetime "created_at"
     t.integer  "actor_id"
   end
 
   add_index "activities", ["actor_id"], name: "index_activities_on_actor_id", using: :btree
   add_index "activities", ["creator_id"], name: "index_activities_on_creator_id", using: :btree
-  add_index "activities", ["trackable_id", "trackable_type"], name: "index_activities_on_trackable_id_and_trackable_type", using: :btree
+  add_index "activities", ["trackable_type", "trackable_id"], name: "index_activities_on_trackable_type_and_trackable_id", using: :btree
 
   create_table "admin_applications", force: :cascade do |t|
     t.integer  "applicant_id"
     t.integer  "lab_id"
     t.text     "notes"
-    t.string   "workflow_state", limit: 255
+    t.string   "workflow_state"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -56,9 +56,9 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "admin_applications", ["applicant_id", "lab_id"], name: "index_admin_applications_on_applicant_id_and_lab_id", using: :btree
 
   create_table "brands", force: :cascade do |t|
-    t.string   "name",           limit: 255
+    t.string   "name"
     t.text     "description"
-    t.string   "workflow_state", limit: 255
+    t.string   "workflow_state"
     t.integer  "creator_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -79,9 +79,9 @@ ActiveRecord::Schema.define(version: 20180710172343) do
 
   create_table "comments", force: :cascade do |t|
     t.integer  "author_id"
-    t.string   "ancestry",         limit: 255
+    t.string   "ancestry"
     t.integer  "commentable_id"
-    t.string   "commentable_type", limit: 255
+    t.string   "commentable_type"
     t.text     "body"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -89,7 +89,7 @@ ActiveRecord::Schema.define(version: 20180710172343) do
 
   add_index "comments", ["ancestry"], name: "index_comments_on_ancestry", using: :btree
   add_index "comments", ["author_id"], name: "index_comments_on_author_id", using: :btree
-  add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
+  add_index "comments", ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id", using: :btree
 
   create_table "contributions", force: :cascade do |t|
     t.integer  "project_id"
@@ -104,59 +104,61 @@ ActiveRecord::Schema.define(version: 20180710172343) do
 
   create_table "coupons", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "description", limit: 255
-    t.string   "code",        limit: 255, null: false
+    t.string   "description"
+    t.string   "code",        null: false
     t.integer  "value"
     t.datetime "redeemed_at"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
+  add_index "coupons", ["code"], name: "index_coupons_on_code", using: :btree
   add_index "coupons", ["user_id"], name: "index_coupons_on_user_id", using: :btree
 
   create_table "discussions", force: :cascade do |t|
-    t.string   "title",            limit: 255
+    t.string   "title"
     t.text     "body"
     t.integer  "discussable_id"
-    t.string   "discussable_type", limit: 255
+    t.string   "discussable_type"
     t.integer  "creator_id"
-    t.string   "workflow_state",   limit: 255
+    t.string   "workflow_state"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "discussions", ["creator_id"], name: "index_discussions_on_creator_id", using: :btree
-  add_index "discussions", ["discussable_id", "discussable_type"], name: "index_discussions_on_discussable_id_and_discussable_type", using: :btree
+  add_index "discussions", ["discussable_type", "discussable_id"], name: "index_discussions_on_discussable_type_and_discussable_id", using: :btree
 
   create_table "documents", force: :cascade do |t|
-    t.string   "type",               limit: 255
-    t.string   "title",              limit: 255
+    t.string   "type"
+    t.string   "title"
     t.text     "description"
-    t.string   "image_file_name",    limit: 255
-    t.string   "image_content_type", limit: 255
+    t.string   "image_file_name"
+    t.string   "image_content_type"
     t.integer  "image_file_size"
     t.datetime "image_updated_at"
     t.integer  "documentable_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "documentable_type",  limit: 255
-    t.string   "photo_uid",          limit: 255
-    t.string   "photo_name",         limit: 255
+    t.string   "documentable_type"
+    t.string   "photo_uid"
+    t.string   "photo_name"
   end
 
   add_index "documents", ["documentable_id"], name: "index_documents_on_documentable_id", using: :btree
+  add_index "documents", ["type"], name: "index_documents_on_type", using: :btree
 
   create_table "employees", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "lab_id"
     t.integer  "ordinal"
-    t.string   "job_title",      limit: 255
-    t.string   "email",          limit: 255
-    t.string   "phone",          limit: 255
+    t.string   "job_title"
+    t.string   "email"
+    t.string   "phone"
     t.text     "description"
     t.date     "started_on"
     t.date     "finished_on"
-    t.string   "workflow_state", limit: 255
+    t.string   "workflow_state"
     t.integer  "creator_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -168,8 +170,8 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "employees", ["user_id"], name: "index_employees_on_user_id", using: :btree
 
   create_table "events", force: :cascade do |t|
-    t.string   "type",        limit: 255
-    t.string   "name",        limit: 255
+    t.string   "type"
+    t.string   "name"
     t.text     "description"
     t.integer  "lab_id"
     t.integer  "creator_id"
@@ -182,7 +184,9 @@ ActiveRecord::Schema.define(version: 20180710172343) do
 
   add_index "events", ["creator_id"], name: "index_events_on_creator_id", using: :btree
   add_index "events", ["lab_id"], name: "index_events_on_lab_id", using: :btree
+  add_index "events", ["starts_at"], name: "index_events_on_starts_at", using: :btree
   add_index "events", ["tags"], name: "index_events_on_tags", using: :btree
+  add_index "events", ["type"], name: "index_events_on_type", using: :btree
 
   create_table "facilities", force: :cascade do |t|
     t.integer  "lab_id"
@@ -207,11 +211,11 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "favourites", ["user_id"], name: "index_favourites_on_user_id", using: :btree
 
   create_table "featured_images", force: :cascade do |t|
-    t.string   "src",            limit: 255
-    t.string   "name",           limit: 255
-    t.string   "description",    limit: 255
-    t.string   "url",            limit: 255
-    t.string   "workflow_state", limit: 255
+    t.string   "src"
+    t.string   "name"
+    t.string   "description"
+    t.string   "url"
+    t.string   "workflow_state"
     t.integer  "creator_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -233,7 +237,7 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   create_table "lab_organizations", force: :cascade do |t|
     t.integer  "lab_id"
     t.integer  "organization_id"
-    t.string   "workflow_state",  limit: 255
+    t.string   "workflow_state"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -242,24 +246,24 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "lab_organizations", ["organization_id"], name: "index_lab_organizations_on_organization_id", using: :btree
 
   create_table "labs", force: :cascade do |t|
-    t.string   "name",                     limit: 255
-    t.string   "slug",                     limit: 255
+    t.string   "name"
+    t.string   "slug"
     t.text     "description"
-    t.string   "ancestry",                 limit: 255
+    t.string   "ancestry"
     t.integer  "creator_id"
-    t.string   "workflow_state",           limit: 255
+    t.string   "workflow_state"
     t.integer  "capabilities"
-    t.string   "time_zone",                limit: 255
-    t.string   "phone",                    limit: 255
-    t.string   "email",                    limit: 255
-    t.string   "address_1",                limit: 255
-    t.string   "address_2",                limit: 255
-    t.string   "city",                     limit: 255
-    t.string   "county",                   limit: 255
-    t.string   "postal_code",              limit: 255
-    t.string   "country_code",             limit: 255
-    t.string   "subregion",                limit: 255
-    t.string   "region",                   limit: 255
+    t.string   "time_zone"
+    t.string   "phone"
+    t.string   "email"
+    t.string   "address_1"
+    t.string   "address_2"
+    t.string   "city"
+    t.string   "county"
+    t.string   "postal_code"
+    t.string   "country_code"
+    t.string   "subregion"
+    t.string   "region"
     t.float    "latitude"
     t.float    "longitude"
     t.integer  "zoom"
@@ -270,37 +274,39 @@ ActiveRecord::Schema.define(version: 20180710172343) do
     t.text     "tools_list"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "blurb",                    limit: 255
+    t.string   "blurb"
     t.integer  "referee_id"
-    t.boolean  "network",                              default: false
-    t.boolean  "programs",                             default: false
-    t.boolean  "tools",                                default: false
-    t.boolean  "charter",                              default: false
-    t.boolean  "public",                               default: false
-    t.string   "discourse_id",             limit: 255
+    t.boolean  "network",                      default: false
+    t.boolean  "programs",                     default: false
+    t.boolean  "tools",                        default: false
+    t.boolean  "charter",                      default: false
+    t.boolean  "public",                       default: false
+    t.string   "discourse_id"
     t.text     "discourse_errors"
-    t.boolean  "is_referee",                           default: false
-    t.string   "avatar_uid",               limit: 255
-    t.string   "avatar_name",              limit: 255
-    t.string   "header_uid",               limit: 255
-    t.string   "header_name",              limit: 255
-    t.string   "activity_status",          limit: 255
+    t.boolean  "is_referee",                   default: false
+    t.string   "avatar_uid"
+    t.string   "avatar_name"
+    t.string   "header_uid"
+    t.string   "header_name"
+    t.string   "activity_status"
     t.date     "activity_start_at"
     t.date     "activity_inaugurated_at"
     t.date     "activity_closed_at"
+    t.text     "improve_approval_application"
   end
 
+  add_index "labs", ["ancestry"], name: "index_labs_on_ancestry", using: :btree
   add_index "labs", ["creator_id"], name: "index_labs_on_creator_id", using: :btree
   add_index "labs", ["referee_id"], name: "index_labs_on_referee_id", using: :btree
-  add_index "labs", ["slug"], name: "index_labs_on_slug", unique: true, using: :btree
+  add_index "labs", ["slug"], name: "index_labs_on_slug", using: :btree
 
   create_table "links", force: :cascade do |t|
     t.integer  "linkable_id"
-    t.string   "linkable_type",  limit: 255
+    t.string   "linkable_type"
     t.integer  "ordinal"
-    t.string   "url",            limit: 255
-    t.string   "description",    limit: 255
-    t.string   "workflow_state", limit: 255
+    t.string   "url"
+    t.string   "description"
+    t.string   "workflow_state"
     t.integer  "creator_id"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -322,25 +328,25 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   create_table "oauth_access_grants", force: :cascade do |t|
     t.integer  "resource_owner_id",              null: false
     t.integer  "application_id",                 null: false
-    t.string   "token",             limit: 255,  null: false
+    t.string   "token",                          null: false
     t.integer  "expires_in",                     null: false
     t.string   "redirect_uri",      limit: 2048, null: false
     t.datetime "created_at",                     null: false
     t.datetime "revoked_at"
-    t.string   "scopes",            limit: 255
+    t.string   "scopes"
   end
 
   add_index "oauth_access_grants", ["token"], name: "index_oauth_access_grants_on_token", unique: true, using: :btree
 
   create_table "oauth_access_tokens", force: :cascade do |t|
     t.integer  "resource_owner_id"
-    t.integer  "application_id",                null: false
-    t.string   "token",             limit: 255, null: false
-    t.string   "refresh_token",     limit: 255
+    t.integer  "application_id",    null: false
+    t.string   "token",             null: false
+    t.string   "refresh_token"
     t.integer  "expires_in"
     t.datetime "revoked_at"
-    t.datetime "created_at",                    null: false
-    t.string   "scopes",            limit: 255
+    t.datetime "created_at",        null: false
+    t.string   "scopes"
   end
 
   add_index "oauth_access_tokens", ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true, using: :btree
@@ -348,9 +354,9 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "oauth_access_tokens", ["token"], name: "index_oauth_access_tokens_on_token", unique: true, using: :btree
 
   create_table "oauth_applications", force: :cascade do |t|
-    t.string   "name",         limit: 255,               null: false
-    t.string   "uid",          limit: 255,               null: false
-    t.string   "secret",       limit: 255,               null: false
+    t.string   "name",                                   null: false
+    t.string   "uid",                                    null: false
+    t.string   "secret",                                 null: false
     t.string   "redirect_uri", limit: 2048,              null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -363,38 +369,38 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "oauth_applications", ["uid"], name: "index_oauth_applications_on_uid", unique: true, using: :btree
 
   create_table "organizations", force: :cascade do |t|
-    t.string   "name",                     limit: 255
+    t.string   "name"
     t.text     "description"
     t.integer  "creator_id"
-    t.string   "slug",                     limit: 255
-    t.string   "kind",                     limit: 255
-    t.string   "blurb",                    limit: 255
-    t.string   "phone",                    limit: 255
-    t.string   "email",                    limit: 255
+    t.string   "slug"
+    t.string   "kind"
+    t.string   "blurb"
+    t.string   "phone"
+    t.string   "email"
     t.text     "application_notes"
-    t.string   "discourse_id",             limit: 255
-    t.string   "discourse_errors",         limit: 255
-    t.string   "workflow_state",           limit: 255
+    t.string   "discourse_id"
+    t.string   "discourse_errors"
+    t.string   "workflow_state"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "geojson"
     t.float    "latitude"
     t.float    "longitude"
     t.integer  "zoom"
-    t.string   "address_1",                limit: 255
-    t.string   "address_2",                limit: 255
-    t.string   "city",                     limit: 255
-    t.string   "county",                   limit: 255
-    t.string   "postal_code",              limit: 255
-    t.string   "country_code",             limit: 255
-    t.string   "subregion",                limit: 255
-    t.string   "region",                   limit: 255
+    t.string   "address_1"
+    t.string   "address_2"
+    t.string   "city"
+    t.string   "county"
+    t.string   "postal_code"
+    t.string   "country_code"
+    t.string   "subregion"
+    t.string   "region"
     t.text     "address_notes"
     t.text     "reverse_geocoded_address"
-    t.string   "avatar_uid",               limit: 255
-    t.string   "avatar_name",              limit: 255
-    t.string   "header_uid",               limit: 255
-    t.string   "header_name",              limit: 255
+    t.string   "avatar_uid"
+    t.string   "avatar_name"
+    t.string   "header_uid"
+    t.string   "header_name"
     t.integer  "order"
   end
 
@@ -402,11 +408,11 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "organizations", ["slug"], name: "index_organizations_on_slug", unique: true, using: :btree
 
   create_table "pages", force: :cascade do |t|
-    t.string   "title",      limit: 255
-    t.string   "slug",       limit: 255
+    t.string   "title"
+    t.string   "slug"
     t.text     "content"
-    t.integer  "position",               default: 0
-    t.boolean  "published",              default: false
+    t.integer  "position",   default: 0
+    t.boolean  "published",  default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -414,34 +420,35 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "pages", ["slug"], name: "index_pages_on_slug", using: :btree
 
   create_table "projects", force: :cascade do |t|
-    t.string   "type",             limit: 255
-    t.string   "title",            limit: 255
+    t.string   "type"
+    t.string   "title"
     t.text     "description"
     t.integer  "lab_id"
     t.integer  "owner_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "status",           limit: 255
-    t.string   "version",          limit: 255
+    t.string   "status"
+    t.string   "version"
     t.text     "faq"
     t.text     "scope"
     t.text     "community"
     t.text     "lookingfor"
-    t.string   "cover",            limit: 255
-    t.string   "discourse_id",     limit: 255
+    t.string   "cover"
+    t.string   "discourse_id"
     t.text     "discourse_errors"
-    t.string   "slug",             limit: 255
+    t.string   "slug"
   end
 
   add_index "projects", ["lab_id"], name: "index_projects_on_lab_id", using: :btree
   add_index "projects", ["owner_id"], name: "index_projects_on_owner_id", using: :btree
   add_index "projects", ["slug"], name: "index_projects_on_slug", unique: true, using: :btree
+  add_index "projects", ["type"], name: "index_projects_on_type", using: :btree
 
   create_table "recoveries", force: :cascade do |t|
     t.integer  "user_id"
-    t.string   "key",            limit: 255
-    t.string   "ip",             limit: 255
-    t.string   "workflow_state", limit: 255
+    t.string   "key"
+    t.string   "ip"
+    t.string   "workflow_state"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -462,7 +469,7 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   create_table "role_applications", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "lab_id"
-    t.string   "workflow_state", limit: 255
+    t.string   "workflow_state"
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -471,9 +478,9 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "role_applications", ["user_id", "lab_id"], name: "index_role_applications_on_user_id_and_lab_id", using: :btree
 
   create_table "roles", force: :cascade do |t|
-    t.string   "name",          limit: 255
+    t.string   "name"
     t.integer  "resource_id"
-    t.string   "resource_type", limit: 255
+    t.string   "resource_type"
     t.datetime "created_at"
     t.datetime "updated_at"
   end
@@ -482,7 +489,7 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "roles", ["name"], name: "index_roles_on_name", using: :btree
 
   create_table "steps", force: :cascade do |t|
-    t.string   "title",       limit: 255
+    t.string   "title"
     t.text     "description"
     t.integer  "position"
     t.integer  "project_id"
@@ -495,9 +502,9 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"
     t.integer  "taggable_id"
-    t.string   "taggable_type", limit: 255
+    t.string   "taggable_type"
     t.integer  "tagger_id"
-    t.string   "tagger_type",   limit: 255
+    t.string   "tagger_type"
     t.string   "context",       limit: 128
     t.datetime "created_at"
   end
@@ -513,28 +520,28 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "taggings", ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
 
   create_table "tags", force: :cascade do |t|
-    t.string  "name",           limit: 255
-    t.integer "taggings_count",             default: 0
+    t.string  "name"
+    t.integer "taggings_count", default: 0
   end
 
   add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "things", force: :cascade do |t|
-    t.string   "name",             limit: 255
+    t.string   "name"
     t.integer  "brand_id"
     t.text     "description"
-    t.string   "workflow_state",   limit: 255
-    t.string   "ancestry",         limit: 255
+    t.string   "workflow_state"
+    t.string   "ancestry"
     t.integer  "creator_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "type",             limit: 255
-    t.boolean  "inventory_item",               default: false
-    t.string   "discourse_id",     limit: 255
+    t.string   "type"
+    t.boolean  "inventory_item",   default: false
+    t.string   "discourse_id"
     t.text     "discourse_errors"
-    t.string   "photo_uid",        limit: 255
-    t.string   "photo_name",       limit: 255
-    t.string   "slug",             limit: 255
+    t.string   "photo_uid"
+    t.string   "photo_name"
+    t.string   "slug"
   end
 
   add_index "things", ["brand_id"], name: "index_things_on_brand_id", using: :btree
@@ -543,48 +550,48 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "things", ["slug"], name: "index_things_on_slug", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "workflow_state",        limit: 255
-    t.string   "first_name",            limit: 255
-    t.string   "last_name",             limit: 255
-    t.string   "email",                 limit: 255
-    t.string   "username",              limit: 255
-    t.string   "password_digest",       limit: 255
-    t.string   "phone",                 limit: 255
-    t.string   "city",                  limit: 255
-    t.string   "country_code",          limit: 255
+    t.string   "workflow_state"
+    t.string   "first_name"
+    t.string   "last_name"
+    t.string   "email"
+    t.string   "username"
+    t.string   "password_digest"
+    t.string   "phone"
+    t.string   "city"
+    t.string   "country_code"
     t.float    "latitude"
     t.float    "longitude"
-    t.string   "url",                   limit: 255
+    t.string   "url"
     t.date     "dob"
     t.text     "bio"
-    t.string   "locale",                limit: 255
-    t.string   "time_zone",             limit: 255
-    t.boolean  "use_metric",                        default: true
-    t.string   "email_validation_hash", limit: 255
+    t.string   "locale"
+    t.string   "time_zone"
+    t.boolean  "use_metric",            default: true
+    t.string   "email_validation_hash"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "fab10_coupon_code",     limit: 255
-    t.integer  "fab10_cost",                        default: 50000
+    t.string   "fab10_coupon_code"
+    t.integer  "fab10_cost",            default: 50000
     t.datetime "fab10_claimed_at"
     t.integer  "fab10_attendee_id"
     t.boolean  "fab10_email_sent"
-    t.string   "vimeo",                 limit: 255
-    t.string   "flickr",                limit: 255
-    t.string   "youtube",               limit: 255
-    t.string   "drive",                 limit: 255
-    t.string   "dropbox",               limit: 255
-    t.string   "twitter",               limit: 255
-    t.string   "facebook",              limit: 255
-    t.string   "web",                   limit: 255
-    t.string   "github",                limit: 255
-    t.string   "bitbucket",             limit: 255
-    t.string   "googleplus",            limit: 255
-    t.string   "instagram",             limit: 255
-    t.boolean  "agree_policy_terms",                default: false
-    t.string   "avatar_uid",            limit: 255
-    t.string   "avatar_name",           limit: 255
-    t.string   "discourse_id",          limit: 255
-    t.string   "slug",                  limit: 255
+    t.string   "vimeo"
+    t.string   "flickr"
+    t.string   "youtube"
+    t.string   "drive"
+    t.string   "dropbox"
+    t.string   "twitter"
+    t.string   "facebook"
+    t.string   "web"
+    t.string   "github"
+    t.string   "bitbucket"
+    t.string   "googleplus"
+    t.string   "instagram"
+    t.boolean  "agree_policy_terms",    default: false
+    t.string   "avatar_uid"
+    t.string   "avatar_name"
+    t.string   "discourse_id"
+    t.string   "slug"
   end
 
   add_index "users", ["fab10_coupon_code"], name: "index_users_on_fab10_coupon_code", unique: true, using: :btree
@@ -598,10 +605,10 @@ ActiveRecord::Schema.define(version: 20180710172343) do
   add_index "users_roles", ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
 
   create_table "versions", force: :cascade do |t|
-    t.string   "item_type",  limit: 255, null: false
-    t.integer  "item_id",                null: false
-    t.string   "event",      limit: 255, null: false
-    t.string   "whodunnit",  limit: 255
+    t.string   "item_type",  null: false
+    t.integer  "item_id",    null: false
+    t.string   "event",      null: false
+    t.string   "whodunnit"
     t.text     "object"
     t.datetime "created_at"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     sequence(:slug) { |n| "fablab#{n}" }
     description { Faker::Lorem.sentence }
     address_1 { Faker::Address.street_address }
+    improve_approval_application { Faker::Lorem.sentence }
     county "County"
     country_code "es"
     network true

--- a/spec/features/backstage/labs/approving_a_lab_spec.rb
+++ b/spec/features/backstage/labs/approving_a_lab_spec.rb
@@ -127,7 +127,7 @@ feature "Approving a lab" do
     sign_out lab_admin_as220
   end
 
-  scenario "referees requests more info" do
+  scenario "referees edit form to request more info" do
     new_lab = FactoryGirl.create(:lab, referee: referee)
     new_lab.referee_approval_processes.create(referee_lab: as220)
     new_lab.referee_approval_processes.create(referee_lab: bcn)
@@ -137,6 +137,19 @@ feature "Approving a lab" do
     expect(lab_admin_bcn.is_referee?).to eq(true)
     visit backstage_lab_path(new_lab)
     click_button "Request more info"
+    expect(page).to have_content("Improve approval application")
+  end
+
+  scenario "referees requests more info" do
+    new_lab = FactoryGirl.create(:lab, referee: referee)
+    new_lab.referee_approval_processes.create(referee_lab: as220)
+    new_lab.referee_approval_processes.create(referee_lab: bcn)
+    new_lab.referee_approval_processes.create(referee_lab: cascina)
+
+    sign_in lab_admin_bcn
+    expect(lab_admin_bcn.is_referee?).to eq(true)
+    visit request_more_info_backstage_lab_path(new_lab)
+    click_button "save"
     expect(page).to have_content("Lab requested more info")
     updated_lab = Lab.find(new_lab.id)
     expect(updated_lab.workflow_state).to eq("need_more_info")
@@ -173,12 +186,11 @@ feature "Approving a lab" do
     sign_out lab_admin_as220
 
     sign_in lab_admin_bcn
+
     expect(lab_admin_bcn.is_referee?).to eq(true)
     visit backstage_lab_path(new_lab)
     click_button "Request more info"
-    expect(page).to have_content("Lab requested more info")
-    updated_lab = Lab.find(new_lab.id)
-    expect(updated_lab.workflow_state).to eq("need_more_info")
+    expect(page).to have_content("Improve approval application")
 
     updated_lab.update_attributes(workflow_state: :more_info_added)
     updated_lab.employees.update_all(workflow_state: :more_info_added)


### PR DESCRIPTION
A form was added to the approval workflow.

Now when an admin/referee clicks the `Request more info` button, she is being redirected to a new page where she can edit the text for the email that will be sent to the lab's creator.