### PR TITLE
remove typo and add license section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Run tests with:
     ./scripts/docker-backup-db.sh
     ```
 
-#### API Documenation
+#### API Documentation
 
 Take a look at the [developer guide](https://docs.fablabs.io) for information on how to
 integrate Fablabs.io in your application.
@@ -94,3 +94,7 @@ the [Examples](https://github.com/fablabbcn/examples.fablabs.io), and the [fabla
 #### Pull requests
 
 All PRs are tested on Travis. Make sure the tests run fine.
+
+#### License
+
+This project is licensed under the GNU Affero General Public License v3.0 (AGPL) - see the [LICENSE.md](https://github.com/fablabbcn/fablabs.io/blob/master/LICENSE) file for details. </br>


### PR DESCRIPTION
Hello! :tada: 

I'm from Brazil and I work on the Public Network of Digital Fabrication Laboratories from São Paulo, Brazil (@fablablivresp). Those are my first (and simple) contributions for this repository.

- Removed a simple typo on README.md file,
- License is explicit in README.md now.

Also, I was thinking on:

1. Make/improve brazillian portuguese translations to this platform. 

2. Contribute with code itself on this platform! _I see that a new version of this platform is coming, so, contributions for this repository are still welcome?_

3. I will create - and maintain - an [awesome-list](https://github.com/sindresorhus/awesome) with nice resources to Fab Labs managers (and communities). So, since you started an globally initiative, I wonder if it's useful to centralize this repo in your org.