### PR TITLE
Fix application dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,9 @@ class ApplicationController < ActionController::Base
 private
 
   def user_time_zone(&block)
-    Time.use_zone(current_user.time_zone, &block)
+    if current_user
+      Time.use_zone(current_user.time_zone , &block)
+    end
   end
 
   def set_locale

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -9,11 +9,11 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
 
 
   def show
-    super
     @token =  Doorkeeper::AccessToken.find_or_create_by(:application_id => @application.id, :resource_owner_id => current_user.id)
     if @token.revoked? || @token.expired? then
       @token =  Doorkeeper::AccessToken.create(:application_id => @application.id, :resource_owner_id => current_user.id)
     end
+    super
   end
 
   # only needed if each application must have some owner

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -9,9 +9,9 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
 
 
   def show
-    @token =  Doorkeeper::AccessToken.find_or_create_by(:application_id => @application.id, :resource_owner_id => current_user.id)
+     @token =  Doorkeeper::AccessToken.find_or_create_by(:application_id => @application.id, :resource_owner_id => current_user.id)
     if @token.revoked? || @token.expired? then
-      @token =  Doorkeeper::AccessToken.create(:application_id => @application.id, :resource_owner_id => current_user.id)
+        @token =  Doorkeeper::AccessToken.create(:application_id => @application.id, :resource_owner_id => current_user.id)
     end
     super
   end
@@ -19,7 +19,7 @@ class Oauth::ApplicationsController < Doorkeeper::ApplicationsController
   # only needed if each application must have some owner
   def create
     @application = Doorkeeper::Application.new(application_params)
-    @application.owner = current_user if Doorkeeper.configuration.confirm_application_owner?
+    @application.owner = current_user # if Doorkeeper.configuration.confirm_application_owner?
     if @application.save
       flash[:notice] = I18n.t(:notice, :scope => [:doorkeeper, :flash, :applications, :create])
       redirect_to oauth_application_url(@application)

--- a/spec/controllers/oauth/applications_controller_spec.rb
+++ b/spec/controllers/oauth/applications_controller_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+
+describe Oauth::ApplicationsController, type: :controller do
+        
+     
+    describe 'GET #index' do
+        render_views
+   
+    
+        it "will redirect to login if not logged in" do
+            get :index
+            path = signin_path
+            expect(response).to redirect_to("/signin?goto=%2Foauth%2Fapplications")
+        end
+
+        it "will show an application list if logged in" do
+            user = FactoryBot.create(:user)
+    
+            session[:user_id] = user.id
+            app = FactoryBot.create(:oauth_application, owner: user)
+
+            get :index
+            status, headers, body = *response
+            expect(response).to be_success
+            expect(response).to render_template(:index)
+            expect(response.body).to include("Your applications")
+            expect(response.body).to include(app.name)
+        end
+
+
+
+    end
+
+
+    describe 'GET #show' do
+        render_views
+
+        before do
+            @user = FactoryBot.create(:user)
+            @anotherUser = FactoryBot.create(:user)
+            @app = FactoryBot.create(:oauth_application, owner: @user)
+    
+        end
+   
+        it "will redirect if not logged in" do
+
+            get :show, id: @app.id
+            path = signin_path
+            expect(response).to redirect_to("/signin?goto=%2Foauth%2Fapplications%2F#{@app.id}")
+        end
+        it "will show an application detail if logged in" do
+
+            session[:user_id] = @user.id
+            get :show, id: @app.id
+
+            status, headers, body = *response
+
+            expect(response).to render_template(:show)
+            expect(assigns(:token)).to be_a(Doorkeeper::AccessToken)
+        end 
+        it "will not show the app if logged in as another user" do
+
+
+            session[:user_id] = @anotherUser.id
+            expect {
+            get :show, id: @app.id
+            }.to raise_error(ActiveRecord::RecordNotFound)
+            #unauthorized
+        end
+
+    end
+
+    describe 'POST #create' do
+
+    end
+
+end

--- a/spec/features/oauth/adding_an_app.spec.rb
+++ b/spec/features/oauth/adding_an_app.spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+feature "Adding an oAuth app" do
+
+    scenario "as a visitor" do
+        visit oauth_applications_path
+        expect(page.title).to match('Sign in')
+      end
+
+    feature "as an authenticated user" do
+
+        given(:user) { FactoryBot.create(:user) }
+
+        background do
+            user.verify!
+            sign_in user
+            visit oauth_applications_path
+            click_link 'New Application'
+        end
+
+        scenario "an authenticated user with all the details filled in" do
+            fill_in 'doorkeeper_application[name]', with: 'My fab project'
+            fill_in 'doorkeeper_application[redirect_uri]', with: 'http://localhost:8080/oauth/callback'
+            click_button 'Submit'
+            expect(page).to have_content('Application created.')
+            expect(page).to have_content('Personal access token:')
+        end
+
+        scenario "an authenticated user with missing redirect url" do
+            fill_in 'doorkeeper_application[name]', with: 'My fab project'
+            click_button 'Submit'
+            expect(page).to have_content('Whoops! Check your form for possible errors')
+        end
+
+        scenario "an authenticated user with missing app name" do
+            fill_in 'doorkeeper_application[redirect_uri]', with: 'http://localhost:8080/oauth/callback'
+            click_button 'Submit'
+            expect(page).to have_content('Whoops! Check your form for possible errors')
+        end
+    end
+end

--- a/spec/features/oauth/adding_an_app.spec.rb
+++ b/spec/features/oauth/adding_an_app.spec.rb
@@ -30,12 +30,14 @@ feature "Adding an oAuth app" do
             fill_in 'doorkeeper_application[name]', with: 'My fab project'
             click_button 'Submit'
             expect(page).to have_content('Whoops! Check your form for possible errors')
+            expect(page).to have_content("Can't be blank")
         end
 
         scenario "an authenticated user with missing app name" do
             fill_in 'doorkeeper_application[redirect_uri]', with: 'http://localhost:8080/oauth/callback'
             click_button 'Submit'
             expect(page).to have_content('Whoops! Check your form for possible errors')
+            expect(page).to have_content("Can't be blank")
         end
     end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,11 @@ Shoulda::Matchers.configure do |config|
     end
 end
 
+def log_test(message)
+  Rails.logger.info(message)
+  puts message
+end
+
 #Capybara.app_host = "www.fablabs.local"
 #Capybara.javascript_driver = :webkit
 


### PR DESCRIPTION
The application dashboard was broken, this PR adds tests and fixes the issue.

- The token was not generated when the application detail view was served. Now checked in a test.
- The app ownership is now enforced without checking the config file.
