### PR TITLE
Use google maps on /labs/map

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -278,13 +278,6 @@ h5 {
     padding-right: 10px !important;
 }
 
-.iframe-embed-map {
-    margin: 0 auto;
-    margin-top: -40px;
-    margin-bottom: 40px;
-    width: 100%;
-}
-
 .btn {
   &.btn-primary {
     background-color: $green;

--- a/app/views/labs/_sidemap.html.erb
+++ b/app/views/labs/_sidemap.html.erb
@@ -21,7 +21,7 @@
       mapTypeId: "OSM",
       mapTypeControl: false,
       streetViewControl: false,
-      zoom: 4
+      zoom: <%= defined?(zoom_level) ? zoom_level : 4 %>
     });
 
     // Define OSM map type pointing at the OpenStreetMap tile server

--- a/app/views/labs/_sidemap.html.erb
+++ b/app/views/labs/_sidemap.html.erb
@@ -1,5 +1,5 @@
-<div class="embed-responsive embed-responsive-4by3 mb-5">
-  <div id="sidemap" class="embed-responsive-item"> </div>
+<div class="border">
+  <div id="sidemap" class="" style="min-height:600px"> </div>
 </div>
 
 <script>

--- a/app/views/labs/map.html.haml
+++ b/app/views/labs/map.html.haml
@@ -16,5 +16,5 @@
           = link_to new_lab_path, class: "btn btn-primary", data: {toggle: "tooltip", placement: "bottom" }, title: "You need to be signed in to add a Lab" do
             = fa_icon "plus", text: t("views.labs.index.add_a_lab", default: "Add Lab")
 
-.container
+.container-fluid
   = render 'sidemap', zoom_level: 2

--- a/app/views/labs/map.html.haml
+++ b/app/views/labs/map.html.haml
@@ -16,14 +16,5 @@
           = link_to new_lab_path, class: "btn btn-primary", data: {toggle: "tooltip", placement: "bottom" }, title: "You need to be signed in to add a Lab" do
             = fa_icon "plus", text: t("views.labs.index.add_a_lab", default: "Add Lab")
 
-.row.iframe-embed-map.row-no-padding
-  .col-12
-    %iframe{frameborder: "0",
-    height: "600",
-    marginheight: "0px",
-    marginwidth: "0px",
-    name: "labsMap",
-    scrolling: "no",
-    src: "embed",
-    style: "border: 0px #FFFFFF none;",
-    width: "100%"}
+.container
+  = render 'sidemap', zoom_level: 2


### PR DESCRIPTION
Was using Mapbox before, which stopped supporting "classic styles"
- http://a.tiles.mapbox.com/v4/mapbox.light/4/9/7.png?access_token=pk.eyJ1IjoidG9tYXNkaWV6IiwiYSI6ImNpaWcyMHU0bjAwM2x2emt1cG5iMzE3bXIifQ.wWNloP12TwdfeKyLHaXpSA
- https://blog.mapbox.com/deprecating-studio-classic-styles-d8892ac38cb4

We could **update** Mapbox, or switch everything to Google Maps, which we are already using in the project and we have a working API key.

Options:
- Remove Mapbox completely? All references, js files etc
- Use Google Maps for all of them instead?
- Is there another alternative? Can we use Leaflet / OpenStreetMap free?

Maps are used in the following places, checked means it is working now:
- [x]  https://fablabs.io/labs/ - Been using Google Maps for months (the map on the right side is a new feature since March 2020)
- [x]  https://fablabs.io/labs/map - Was using MapBox, now using Google Maps
- [ ]  https://fablabs.io/labs/embed - Still using MapBox. Where is this used?
- [ ] Check all references for mapbox / map and see if all maps are working