### PR TITLE
Allow fetching a user by ID in admin API

### DIFF
--- a/app/controllers/api/v2/admin_controller.rb
+++ b/app/controllers/api/v2/admin_controller.rb
@@ -62,6 +62,11 @@ class Api::V2::AdminController < Api::V2::ApiController
     error! :forbidden unless current_user.has_role? :superadmin
     options = {}
     @user = User.where('username = ? ', params[:username]).first
+
+    if @user.blank? and params[:username].to_i.to_s == params[:username]
+        @user = User.where('id = ? ', params[:username]).first
+    end
+
     render_json ApiUserSerializer.new(@user, options).serialized_json
   end
 


### PR DESCRIPTION
I'm creating a script where it would be useful to fetch users by ID. There already seems to be a GET user route, though it is using the username parameter. To not break compatibility, I thought to just adjust that if the key would be an integer, fetch record by ID. I am not a Ruby person, so not sure if this is the best way, but thought along these lines, the change, has the least disruption.

So the urls `/2/users/mactwister` or `/2/users/123456` would return the same user.