### PR TITLE
Updates get_user API to fetch records using the slug

### DIFF
--- a/app/controllers/api/v2/admin_controller.rb
+++ b/app/controllers/api/v2/admin_controller.rb
@@ -61,7 +61,7 @@ class Api::V2::AdminController < Api::V2::ApiController
   def get_user
     error! :forbidden unless current_user.has_role? :superadmin
     options = {}
-    @user = User.where('username = ? ', params[:username]).first
+    @user = User.friendly.find(params[:slug])
     render_json ApiUserSerializer.new(@user, options).serialized_json
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,7 +205,7 @@ Rails.application.routes.draw do
       get 'users/me' => 'user#me'
       post 'users/me' => 'user#update_user'
       post 'users/search' => 'admin#search_users'
-      get 'users/:username' => 'admin#get_user'
+      get 'users/:slug' => 'admin#get_user'
 
       # labs
       get 'labs' => 'labs#index'
@@ -216,7 +216,7 @@ Rails.application.routes.draw do
       put 'labs/:id' => 'labs#update'
       get 'labs/:id/relationships/machines' => 'labs#get_lab_machines_by_id'
       post 'labs/:id/relationships/machines' => 'labs#add_lab_machine_by_id'
- 
+
       # projects
       get 'projects' => 'projects#index'
       post 'projects' => 'projects#create'

--- a/spec/controllers/api/v2/admin_controller_spec.rb
+++ b/spec/controllers/api/v2/admin_controller_spec.rb
@@ -38,13 +38,14 @@ describe Api::V2::AdminController, type: :request do
     end
   end
 
-  describe 'GET users#get_user' do
-    the_username = 'firstsecond'
+  describe 'GET users#get_user with dot in username' do
+    the_username = 'first.second'
     let!(:user) { FactoryBot.create :user, username: the_username }
 
     it 'returns a single user' do
       user.add_role :superadmin
-      get_as_user "http://api.fablabs.dev/2/users/#{the_username}"
+      username_slug = the_username.gsub('.', '-')
+      get_as_user "http://api.fablabs.dev/2/users/#{username_slug}"
       expect(response.status).to eq(200)
       expect(response.content_type).to eq(Mime[:json])
       expect(JSON.parse(response.body)['data']['attributes']['username']).to eq(the_username)


### PR DESCRIPTION
Since username could have special characters (ie. a period), best to fetch users using the slug property. Rails parses periods, therefore does not get past to the model query.

I also updated the test, to be with a period.