### PR TITLE
Search for users if params provided

### DIFF
--- a/app/controllers/api/v2/admin_controller.rb
+++ b/app/controllers/api/v2/admin_controller.rb
@@ -41,14 +41,18 @@ class Api::V2::AdminController < Api::V2::ApiController
     error! :forbidden unless current_user.has_role? :superadmin
 
     data = params.require(:data).permit(:username, :email)
-    @username = data.fetch('username', '')
-    @email = data.fetch('email', '')
 
-    @users, @paginate = paginate User.where(
-      'UPPER(username) = UPPER(?) or UPPER(email) = UPPER(?)',
-      @username.to_s,
-      @email.to_s
-    )
+    @query = User.all
+
+    if data['username'].present?
+      @query = @query.where('UPPER(username) = UPPER(?)', data['username'].to_s)
+    end
+
+    if data['email'].present?
+      @query = @query.where('UPPER(email) = UPPER(?)', data['email'].to_s)
+    end
+
+    @users, @paginate = paginate @query
 
     # Your code hereda
     options = {}


### PR DESCRIPTION
So :)

If I wanted to use this API to search for only the username, feel it was better to omit searching an empty string.

However, what I wanted to do, was to add an OR clause if the username query was added but was unable to figure out how quickly enough.

ie. 
- Search only username
- Search only email
- Search username **OR** email (CURRENTLY an AND)