### PR TITLE
Sets a default scope for Doorkeeper OAuth gem

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -43,7 +43,7 @@ Doorkeeper.configure do
 
   # Define access token scopes for your provider
   # For more information go to https://github.com/applicake/doorkeeper/wiki/Using-Scopes
-  # default_scopes  :public
+  default_scopes  :public
   # optional_scopes :write, :update
 
   # Change the way client credentials are retrieved from the request object.


### PR DESCRIPTION
From Doorkeepr version 5.2.x onwards, a `scope` param needs to be provided for oauth requests. This default scope will be used for applications/requests that do not specify one. 

I've gone with the doorkeepr default scope of `public` as we only use this mostly for 3rd party login and have no APIs using scopes, so public felt appropriate to me as in "Access your public data". 

With this change we can safely upgrade to the latest v5 of Doorkeeper.

Can close #587 