### PR TITLE
Do not skip asking users for authorization to OAuth apps

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -72,7 +72,7 @@ Doorkeeper.configure do
   # # so that the user skips the authorization step.
   # # For example if dealing with trusted a application.
   skip_authorization do |resource_owner, client|
-    true
+    false
     # client.superapp? or resource_owner.admin?
   end
 end


### PR DESCRIPTION
Typically, in OAuth grant flows, the user needs to confirm the requesting app can access your profile (the first time). I think  this is a nice privacy check, to make sure this is the user's intention. It's happened to me, that I accidentally click login, all of a sudden, I have an account.

This will also add an extra "click" step, for all the fake account bots. I'm uncertain if this will have an impact, but it will be an extra step towards signups in (i.e., Forums, GitLab, etc). 

I am not aware of any possible impacts, apart from new first time logins to apps.

See doorkeeper docs on [Skip Authorization](https://doorkeeper.gitbook.io/guides/configuration/skip-authorization)

![doorkeeper authorization window](https://user-images.githubusercontent.com/1853847/146172145-c30205d9-4212-499d-862c-54b65ecd6de9.png)
