### PR TITLE
Homepage & Signup page copy changes

### DIFF
--- a/app/views/static/alt.html.haml
+++ b/app/views/static/alt.html.haml
@@ -1,10 +1,11 @@
 - title t("views.home.welcome")
 
-.container.mb-5
-  = render 'static/alt/corona'
 .bg-grey
   = render 'static/alt/hero'
 = render 'static/alt/features'
+.p-5.bg-grey
+  .container
+    = render 'static/alt/corona'
 .py-5.bg-primary
   = render 'static/alt/banner'
 .py-5.bg-grey

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -1,9 +1,4 @@
 .container
-  %h1.my-5 Important message!
-  %p Fablabs.io has temporary closed the sign up process due to the amount of spam we have been receiving over the last couple of months.
-  %p We are currently working on fixing the problem as soon as possible.
-  %p If you are urging any assistance or are willing to receive a notification once the system is back up, please don’t hesitaste to write us at <a href="mailto:forum@fabfoundation.org">forum@fabfoundation.org</a>
-
   = simple_form_for @user do |f|
     %fieldset
       .form-header


### PR DESCRIPTION
Helping @bnore make some copy changes

1. Removed "signups blocked" text as, they are actually open.
2. Move the covid message lower on the homepage.

Let me know if this looks good?

![Screenshot homepage corona text moved](https://user-images.githubusercontent.com/1853847/151167098-2599b92a-d0b3-4324-8983-4aa130abcac0.png)
