### PR TITLE
Revert "Sets a default scope for Doorkeeper OAuth gem"

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -43,7 +43,7 @@ Doorkeeper.configure do
 
   # Define access token scopes for your provider
   # For more information go to https://github.com/applicake/doorkeeper/wiki/Using-Scopes
-  default_scopes  :public
+  # default_scopes  :public
   # optional_scopes :write, :update
 
   # Change the way client credentials are retrieved from the request object.


### PR DESCRIPTION
Reverts fablabbcn/fablabs.io#588

Tests failing, see:

https://github.com/fablabbcn/fablabs.io/runs/4963770452?check_suite_focus=true