### PR TITLE
Restrict Doorkeeper application pages from new users

### DIFF
--- a/app/admin/doorkeeper_applications.rb
+++ b/app/admin/doorkeeper_applications.rb
@@ -5,7 +5,7 @@ ActiveAdmin.register Doorkeeper::Application do
   #
   # Uncomment all parameters which should be permitted for assignment
   #
-  # permit_params :name, :uid, :secret, :redirect_uri, :scopes, :owner_id, :owner_type, :confidential
+  permit_params :name, :redirect_uri, :scopes, :confidential
   #
   # or
   #
@@ -19,4 +19,18 @@ ActiveAdmin.register Doorkeeper::Application do
   remove_filter :access_tokens
   remove_filter :authorized_tokens
   remove_filter :authorized_applications
+
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :redirect_uri
+    column :owner
+    column :owner_type
+    column :scopes
+    column :confidential
+    column :created_at
+    column :updated_at
+    actions
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,6 +161,8 @@ class User < ActiveRecord::Base
 
   def passed_spam_period?
     return true if Rails.env.test?
+    
+    return true if superadmin?
 
     created_at < 2.months.ago
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -160,8 +160,6 @@ class User < ActiveRecord::Base
   end
 
   def passed_spam_period?
-    return true if Rails.env.test?
-    
     return true if superadmin?
 
     created_at < 2.months.ago

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -75,10 +75,14 @@
                     = t("views.header.backstage", default: "Backstage")
                     = gem_count_tag current_or_null_user.pending_referee_labs.count
 
+              %li.divider
               - if current_user.passed_spam_period?
-                %li.divider
                 = link_to oauth_applications_path, class: 'dropdown-item'  do
                   = fa_icon "code", text: t("views.header.developer_console", default: "Developer Console"), class: 'fa-fw'
+              -else
+                %a.dropdown-item.disabled{:role => "button", "aria-disabled" => "true"}  
+                  = t("views.header.developer_console", default: "Developer Console")
+
               %li.divider
               = link_to signout_path, class: 'dropdown-item'  do
                 = fa_icon "sign-out", text: t("views.header.signout", default: "Sign out"), class: 'fa-fw'

--- a/app/views/application/_header.html.haml
+++ b/app/views/application/_header.html.haml
@@ -75,7 +75,7 @@
                     = t("views.header.backstage", default: "Backstage")
                     = gem_count_tag current_or_null_user.pending_referee_labs.count
 
-              - if current_user.created_at < 1.months.ago
+              - if current_user.passed_spam_period?
                 %li.divider
                 = link_to oauth_applications_path, class: 'dropdown-item'  do
                   = fa_icon "code", text: t("views.header.developer_console", default: "Developer Console"), class: 'fa-fw'

--- a/app/views/doorkeeper/authorizations/form_post.html.erb
+++ b/app/views/doorkeeper/authorizations/form_post.html.erb
@@ -2,10 +2,14 @@
   <h1><%= t('.title') %></h1>
 </header>
 
-<main role="main" onload="document.forms[0].submit()">
-  <%= form_tag @pre_auth.redirect_uri, method: :post do %>
-    <% @authorize_response.body.each do |key, value| %>
-      <%= hidden_field_tag key, value %>
-    <% end %>
+<%= form_tag @pre_auth.redirect_uri, method: :post, name: :redirect_form, authenticity_token: false do %>
+  <% @authorize_response.body.compact.each do |key, value| %>
+    <%= hidden_field_tag key, value %>
   <% end %>
-</main>
+<% end %>
+
+<script>
+  window.onload = function () {
+    document.forms['redirect_form'].submit();
+  };
+</script>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -30,6 +30,7 @@
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+      <%= hidden_field_tag :response_mode, @pre_auth.response_mode %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>
@@ -47,6 +48,7 @@
       <%= hidden_field_tag :redirect_uri, @pre_auth.redirect_uri %>
       <%= hidden_field_tag :state, @pre_auth.state %>
       <%= hidden_field_tag :response_type, @pre_auth.response_type %>
+      <%= hidden_field_tag :response_mode, @pre_auth.response_mode %>
       <%= hidden_field_tag :scope, @pre_auth.scope %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -33,7 +33,7 @@
       <%= hidden_field_tag :scope, @pre_auth.scope %>
       <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge %>
       <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method %>
-      <%= submit_tag t('doorkeeper.authorizations.buttons.authorize'), class: "btn btn-success btn-lg btn-block" %>
+      <%= submit_tag t('doorkeeper.authorizations.buttons.authorize', for: current_user.username), class: "btn btn-success btn-lg btn-block" %>
     <% end %>
 
     <p class="my-4 text-center text-info">

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -22,7 +22,8 @@
         = f.input :bio, input_html: { rows: 5 }
         = f.input :url
       - else
-        %p Because of high amount of spam users, biography will only be available after 2 months of activity.
+        .alert.alert-warning.mt-2{:role => "alert"}
+          %p Because of high amount of spam users, the biography section, will only be available after being a member for two months.
 
     - if @user.passed_spam_period?
       %fieldset

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -18,12 +18,13 @@
           = fa_icon "key", text: "Change Password"
 
       .my-3
-        - if @user.passed_spam_period?
-          - if @user.bio?
+        - if @user.bio?
+          - if @user.passed_spam_period?
             %h5 Bio
             = simple_format @user.bio
-        - else
-          %p Because of high amount of spam users, biography will only be shown after 2 months of activity.
+          - else
+            .alert.alert-warning{:role => "alert"}
+              %p Because of high amount of spam users, the biography will only be shown after the user has been a memeber for two months.
 
       = render "links", links: @user.links if @user.passed_spam_period?
 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -16,13 +16,17 @@ Doorkeeper.configure do
     User.find_by_id(session[:user_id]) || redirect_to(signin_url(goto: request.fullpath))
   end
 
-  # If you want to restrict access to the web interface for adding oauth authorized applications, you need to declare the block below.
-  # FB: disabling the block below to allow users to access the outh/applications page
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
   admin_authenticator do
-    # Put your admin authentication logic here.
-    # Example implementation:
-    # ((user = User.find_by(id: session[:user_id])) && user.has_role?(:superadmin)) || redirect_to(root_path)
-    User.find_by_id(session[:user_id]) || redirect_to(signin_url(goto: request.fullpath))
+    if current_user
+      head :forbidden unless current_user.passed_spam_period?
+    else
+      redirect_to signin_url goto: request.fullpath 
+    end
   end
 
   # Authorization Code expiration time (default 10 minutes).

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -52,7 +52,7 @@ en:
 
     authorizations:
       buttons:
-        authorize: 'Authorize'
+        authorize: 'Authorize for "%{for}"'
         deny: 'Deny'
       error:
         title: 'An error has occurred'


### PR DESCRIPTION
* Prevent direct visit of oauth URLs
    _Though the menu item was hidden for the "developer dashboard", the page/routes were still active. This adds a check to the Doorkeepers config, which gets included for all OAuth related pages to run the same check._
* Show oauth application link in nav but disabled
* Show username that is logged-in to `api.fablabs.io` (because page has no main menu)